### PR TITLE
Refactor : Activity 리팩토링

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@
 			<artifactId>aws-java-sdk</artifactId>
 			<version>1.11.1000</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
@@ -12,12 +12,15 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @RestController
-@RequiredArgsConstructor
 public class ActivityController {
 
     private final ActivityService activityService;
 
-    @PostMapping("/activity")
+    public ActivityController(ActivityService activityService) {
+        this.activityService = activityService;
+    }
+
+    @PostMapping("/activities")
     public ActivityResponse create(@RequestParam("name") String name,
         @RequestParam("score") Integer score,
         @RequestParam("description") String description,
@@ -27,7 +30,7 @@ public class ActivityController {
         return activityService.create(activityRequest, multipartFile);
     }
 
-    @PutMapping("/activity/{id}")
+    @PutMapping("/activities/{id}")
     public ActivityResponse update(@PathVariable("id") Integer id,
         @RequestParam("name") String name,
         @RequestParam("score") Integer score,
@@ -38,19 +41,19 @@ public class ActivityController {
         return activityService.update(id, activityRequest, multipartFile);
     }
 
-    @GetMapping("/activity/{id}")
-    public ActivityDetailResponse getActivity(@PathVariable("id") Integer id) {
-        return activityService.getActivity(id);
+    @GetMapping("/activities/{id}")
+    public ActivityDetailResponse activity(@PathVariable("id") Integer id) {
+        return activityService.activity(id);
     }
 
     @GetMapping("/activities")
-    public List<ActivityResponse> getActivities() {
-        return activityService.getActivities();
+    public List<ActivityResponse> activities() {
+        return activityService.activities();
     }
 
-    @DeleteMapping("/activity/{id}")
-    public String delete(@PathVariable("id") Integer id) {
-        return activityService.deleteActivity(id);
+    @DeleteMapping("/activities/{id}")
+    public void delete(@PathVariable("id") Integer id) {
+        activityService.delete(id);
     }
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
@@ -1,8 +1,10 @@
 package com.yunhalee.walkerholic.activity.controller;
 
-import com.yunhalee.walkerholic.activity.dto.ActivityCreateDTO;
-import com.yunhalee.walkerholic.activity.dto.ActivityDTO;
+import com.yunhalee.walkerholic.activity.dto.ActivityRequest;
+import com.yunhalee.walkerholic.activity.dto.ActivityResponse;
+import com.yunhalee.walkerholic.activity.dto.ActivityDetailResponse;
 import com.yunhalee.walkerholic.activity.service.ActivityService;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,33 +17,40 @@ public class ActivityController {
 
     private final ActivityService activityService;
 
-    @PostMapping("/activity/save")
-    public ActivityCreateDTO saveActivity(@RequestParam(value = "id", required = false) Integer id,
+    @PostMapping("/activity")
+    public ActivityResponse create(@RequestParam("name") String name,
+        @RequestParam("score") Integer score,
+        @RequestParam("description") String description,
+        @RequestParam(value = "multipartFile", required = false) MultipartFile multipartFile)
+        throws IOException {
+        ActivityRequest activityRequest = new ActivityRequest(name, score, description);
+        return activityService.create(activityRequest, multipartFile);
+    }
+
+    @PutMapping("/activity/{id}")
+    public ActivityResponse update(@PathVariable("id") Integer id,
         @RequestParam("name") String name,
         @RequestParam("score") Integer score,
         @RequestParam("description") String description,
-        @RequestParam(value = "multipartFile", required = false) MultipartFile multipartFile) {
-
-        ActivityCreateDTO activityCreateDTO = new ActivityCreateDTO(id, name, score, description);
-        return id != null ? activityService.updateActivity(activityCreateDTO, multipartFile)
-            : activityService.createActivity(activityCreateDTO, multipartFile);
+        @RequestParam(value = "multipartFile", required = false) MultipartFile multipartFile)
+        throws IOException {
+        ActivityRequest activityRequest = new ActivityRequest(name, score, description);
+        return activityService.update(id, activityRequest, multipartFile);
     }
 
     @GetMapping("/activity/{id}")
-    public ActivityDTO getActivity(@PathVariable("id") String id) {
-        Integer activityId = Integer.parseInt(id);
-        return activityService.getActivity(activityId);
+    public ActivityDetailResponse getActivity(@PathVariable("id") Integer id) {
+        return activityService.getActivity(id);
     }
 
     @GetMapping("/activities")
-    public List<ActivityCreateDTO> getActivities() {
+    public List<ActivityResponse> getActivities() {
         return activityService.getActivities();
     }
 
-    @DeleteMapping("/deleteActivity/{id}")
-    public String deleteActivity(@PathVariable("id") String id) {
-        Integer activityId = Integer.parseInt(id);
-        return activityService.deleteActivity(activityId);
+    @DeleteMapping("/activity/{id}")
+    public String delete(@PathVariable("id") Integer id) {
+        return activityService.deleteActivity(id);
     }
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
@@ -15,7 +15,7 @@ public class ActivityController {
 
     private final ActivityService activityService;
 
-  @PostMapping("/activity/save")
+    @PostMapping("/activity/save")
     public ActivityCreateDTO saveActivity(@RequestParam(value = "id", required = false) Integer id,
         @RequestParam("name") String name,
         @RequestParam("score") Integer score,
@@ -23,7 +23,8 @@ public class ActivityController {
         @RequestParam(value = "multipartFile", required = false) MultipartFile multipartFile) {
 
         ActivityCreateDTO activityCreateDTO = new ActivityCreateDTO(id, name, score, description);
-        return activityService.saveActivity(activityCreateDTO, multipartFile);
+        return id != null ? activityService.updateActivity(activityCreateDTO, multipartFile)
+            : activityService.createActivity(activityCreateDTO, multipartFile);
     }
 
     @GetMapping("/activity/{id}")

--- a/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/controller/ActivityController.java
@@ -5,6 +5,7 @@ import com.yunhalee.walkerholic.activity.dto.ActivityResponse;
 import com.yunhalee.walkerholic.activity.dto.ActivityDetailResponse;
 import com.yunhalee.walkerholic.activity.service.ActivityService;
 import java.io.IOException;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @RestController
+@RequestMapping("/activities")
 public class ActivityController {
 
     private final ActivityService activityService;
@@ -20,38 +22,34 @@ public class ActivityController {
         this.activityService = activityService;
     }
 
-    @PostMapping("/activities")
-    public ActivityResponse create(@RequestParam("name") String name,
-        @RequestParam("score") Integer score,
-        @RequestParam("description") String description,
-        @RequestParam(value = "multipartFile", required = false) MultipartFile multipartFile)
-        throws IOException {
-        ActivityRequest activityRequest = new ActivityRequest(name, score, description);
-        return activityService.create(activityRequest, multipartFile);
+    @PostMapping
+    public ActivityResponse create(@Valid @RequestBody ActivityRequest activityRequest) {
+        return activityService.create(activityRequest);
     }
 
-    @PutMapping("/activities/{id}")
+    @PutMapping("/{id}")
     public ActivityResponse update(@PathVariable("id") Integer id,
-        @RequestParam("name") String name,
-        @RequestParam("score") Integer score,
-        @RequestParam("description") String description,
-        @RequestParam(value = "multipartFile", required = false) MultipartFile multipartFile)
-        throws IOException {
-        ActivityRequest activityRequest = new ActivityRequest(name, score, description);
-        return activityService.update(id, activityRequest, multipartFile);
+        @Valid @RequestBody ActivityRequest activityRequest) {
+        return activityService.update(id, activityRequest);
     }
 
-    @GetMapping("/activities/{id}")
+    @PostMapping("/image")
+    public String uploadImage(@RequestParam("multipartFile") MultipartFile multipartFile)
+        throws IOException {
+        return activityService.uploadImage(multipartFile);
+    }
+
+    @GetMapping("/{id}")
     public ActivityDetailResponse activity(@PathVariable("id") Integer id) {
         return activityService.activity(id);
     }
 
-    @GetMapping("/activities")
+    @GetMapping
     public List<ActivityResponse> activities() {
         return activityService.activities();
     }
 
-    @DeleteMapping("/activities/{id}")
+    @DeleteMapping("/{id}")
     public void delete(@PathVariable("id") Integer id) {
         activityService.delete(id);
     }

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -44,12 +44,16 @@ public class Activity {
     }
 
     // 비지니스 로직
-    public Activity updateActivity( Activity requestActivity) {
+    public Activity update(Activity requestActivity) {
         this.name = requestActivity.name;
         this.description = requestActivity.description;
         this.score = requestActivity.score;
 
         return this;
+    }
+
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -13,7 +13,6 @@ import java.util.Set;
 @Table(name = "activity")
 @Getter
 @Setter
-@NoArgsConstructor
 public class Activity {
 
     @Id
@@ -36,6 +35,9 @@ public class Activity {
     @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("createdAt DESC")
     private Set<UserActivity> userActivities = new HashSet<>();
+
+    public Activity() {
+    }
 
     public Activity(String name, Integer score, String description) {
         this.name = name;

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -45,17 +45,27 @@ public class Activity {
         this.description = description;
     }
 
+    public Activity(String name, Integer score, String description, String imageUrl) {
+        this.name = name;
+        this.score = score;
+        this.description = description;
+        this.imageUrl = imageUrl;
+    }
+
     // 비지니스 로직
     public Activity update(Activity requestActivity) {
         this.name = requestActivity.name;
         this.description = requestActivity.description;
         this.score = requestActivity.score;
+        this.imageUrl = requestActivity.imageUrl;
 
         return this;
     }
 
-    public void changeImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+    public void setDefaultImageUrl(String imageUrl, String defaultImageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty() || imageUrl.isBlank()) {
+            this.imageUrl = defaultImageUrl;
+        }
     }
 
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/domain/Activity.java
@@ -43,7 +43,14 @@ public class Activity {
         this.description = description;
     }
 
+    // 비지니스 로직
+    public Activity updateActivity( Activity requestActivity) {
+        this.name = requestActivity.name;
+        this.description = requestActivity.description;
+        this.score = requestActivity.score;
 
+        return this;
+    }
 
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityCreateDTO.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityCreateDTO.java
@@ -40,5 +40,9 @@ public class ActivityCreateDTO {
         this.description = description;
     }
 
+    public Activity toActivity(){
+        return new Activity(name, score, description);
+    }
+
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityDetailResponse.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityDetailResponse.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 @Getter
 @Setter
-public class ActivityDTO {
+public class ActivityDetailResponse {
 
     private Integer id;
 
@@ -26,7 +26,7 @@ public class ActivityDTO {
 
     private List<ActivityUser> activityUsers;
 
-    public ActivityDTO(Activity activity) {
+    public ActivityDetailResponse(Activity activity) {
         this.id = activity.getId();
         this.name = activity.getName();
         this.score = activity.getScore();

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
@@ -1,7 +1,6 @@
 package com.yunhalee.walkerholic.activity.dto;
 
 import com.yunhalee.walkerholic.activity.domain.Activity;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
@@ -1,6 +1,8 @@
 package com.yunhalee.walkerholic.activity.dto;
 
 import com.yunhalee.walkerholic.activity.domain.Activity;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,21 +10,27 @@ import lombok.Setter;
 @Setter
 public class ActivityRequest {
 
+    @NotNull
     private String name;
 
+    @NotNull
     private Integer score;
 
+    @NotNull
     private String description;
 
-    public ActivityRequest(String name, Integer score, String description) {
+    private String imageUrl;
+
+    @Builder
+    public ActivityRequest(String name, Integer score, String description, String imageUrl) {
         this.name = name;
         this.score = score;
         this.description = description;
+        this.imageUrl = imageUrl;
     }
 
-
     public Activity toActivity() {
-        return new Activity(name, score, description);
+        return new Activity(name, score, description, imageUrl);
     }
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityRequest.java
@@ -1,0 +1,29 @@
+package com.yunhalee.walkerholic.activity.dto;
+
+import com.yunhalee.walkerholic.activity.domain.Activity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ActivityRequest {
+
+    private String name;
+
+    private Integer score;
+
+    private String description;
+
+    public ActivityRequest(String name, Integer score, String description) {
+        this.name = name;
+        this.score = score;
+        this.description = description;
+    }
+
+
+    public Activity toActivity() {
+        return new Activity(name, score, description);
+    }
+
+}

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
@@ -4,7 +4,6 @@ import com.yunhalee.walkerholic.activity.domain.Activity;
 import lombok.Getter;
 import lombok.Setter;
 
-
 @Getter
 @Setter
 public class ActivityResponse {

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ActivityCreateDTO {
+public class ActivityResponse {
 
     private Integer id;
 
@@ -19,14 +19,7 @@ public class ActivityCreateDTO {
 
     private String imageUrl;
 
-    public ActivityCreateDTO(Integer id, String name, Integer score, String description) {
-        this.id = id;
-        this.name = name;
-        this.score = score;
-        this.description = description;
-    }
-
-    public ActivityCreateDTO(Activity activity) {
+    public ActivityResponse(Activity activity) {
         this.id = activity.getId();
         this.name = activity.getName();
         this.score = activity.getScore();
@@ -34,15 +27,8 @@ public class ActivityCreateDTO {
         this.imageUrl = activity.getImageUrl();
     }
 
-    public ActivityCreateDTO(String name, Integer score, String description) {
-        this.name = name;
-        this.score = score;
-        this.description = description;
-    }
-
-    public Activity toActivity(){
+    public Activity toActivity() {
         return new Activity(name, score, description);
     }
-
 
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/dto/ActivityResponse.java
@@ -26,8 +26,4 @@ public class ActivityResponse {
         this.imageUrl = activity.getImageUrl();
     }
 
-    public Activity toActivity() {
-        return new Activity(name, score, description);
-    }
-
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/exception/ActivityNotFoundException.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/exception/ActivityNotFoundException.java
@@ -1,6 +1,6 @@
 package com.yunhalee.walkerholic.activity.exception;
 
-public class ActivityNotFoundException extends RuntimeException{
+public class ActivityNotFoundException extends RuntimeException {
 
     public ActivityNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/yunhalee/walkerholic/activity/exception/ActivityNotFoundException.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/exception/ActivityNotFoundException.java
@@ -1,0 +1,17 @@
+package com.yunhalee.walkerholic.activity.exception;
+
+public class ActivityNotFoundException extends RuntimeException{
+
+    public ActivityNotFoundException(String message) {
+        super(message);
+    }
+
+    public ActivityNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ActivityNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/com/yunhalee/walkerholic/activity/exception/ActivityNotFoundException.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/exception/ActivityNotFoundException.java
@@ -1,6 +1,8 @@
 package com.yunhalee.walkerholic.activity.exception;
 
-public class ActivityNotFoundException extends RuntimeException {
+import com.yunhalee.walkerholic.common.exception.EntityNotFoundException;
+
+public class ActivityNotFoundException extends EntityNotFoundException {
 
     public ActivityNotFoundException(String message) {
         super(message);
@@ -13,5 +15,4 @@ public class ActivityNotFoundException extends RuntimeException {
     public ActivityNotFoundException(Throwable cause) {
         super(cause);
     }
-
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/service/ActivityService.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/service/ActivityService.java
@@ -2,38 +2,47 @@ package com.yunhalee.walkerholic.activity.service;
 
 import com.yunhalee.walkerholic.activity.dto.ActivityRequest;
 import com.yunhalee.walkerholic.activity.exception.ActivityNotFoundException;
-import com.yunhalee.walkerholic.util.AmazonS3Utils;
+import com.yunhalee.walkerholic.common.service.S3ImageUploader;
 import com.yunhalee.walkerholic.activity.dto.ActivityResponse;
 import com.yunhalee.walkerholic.activity.dto.ActivityDetailResponse;
 import com.yunhalee.walkerholic.activity.domain.Activity;
 import com.yunhalee.walkerholic.activity.domain.ActivityRepository;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ActivityService {
 
-    private final ActivityRepository activityRepository;
+    private ActivityRepository activityRepository;
 
-    private final AmazonS3Utils amazonS3Utils;
+    private S3ImageUploader s3ImageUploader;
 
+    private static final String UPLOAD_DIR = "activityUploads/";
 
+    public ActivityService(
+        ActivityRepository activityRepository,
+        S3ImageUploader s3ImageUploader) {
+        this.activityRepository = activityRepository;
+        this.s3ImageUploader = s3ImageUploader;
+    }
+
+    @Transactional
     public ActivityResponse create(ActivityRequest activityRequest,
         MultipartFile multipartFile) throws IOException {
         Activity activity = activityRequest.toActivity();
-        saveActivityImage(activity, multipartFile);
-
         activityRepository.save(activity);
+        saveImage(activity, multipartFile);
 
         return new ActivityResponse(activity);
     }
 
+    @Transactional
     public ActivityResponse update(Integer id, ActivityRequest activityRequest,
         MultipartFile multipartFile) throws IOException {
         Activity existingActivity = activityRepository.findById(id)
@@ -41,51 +50,39 @@ public class ActivityService {
                 "Activity not found with id : " + id));
         Activity requestActivity = activityRequest.toActivity();
         Activity updatedActivity = existingActivity.update(requestActivity);
-        saveActivityImage(updatedActivity, multipartFile);
-
-        activityRepository.save(updatedActivity);
+        saveImage(updatedActivity, multipartFile);
 
         return new ActivityResponse(existingActivity);
     }
 
 
-    public ActivityDetailResponse getActivity(Integer id) {
+    public ActivityDetailResponse activity(Integer id) {
         Activity activity = activityRepository.findByActivityId(id);
         ActivityDetailResponse activityDetailResponse = new ActivityDetailResponse(activity);
 
         return activityDetailResponse;
     }
 
-    public List<ActivityResponse> getActivities() {
-        List<Activity> activities = activityRepository.findAll();
-        List<ActivityResponse> activityResponses = new ArrayList<>();
-        activities.forEach(activity -> activityResponses.add(new ActivityResponse(activity)));
-        return activityResponses;
+    public List<ActivityResponse> activities() {
+        return activityRepository.findAll().stream().map(ActivityResponse::new)
+            .collect(Collectors.toList());
     }
 
-    public String deleteActivity(Integer id) {
-        String dir = "activityUploads/" + id;
-        amazonS3Utils.removeFolder(dir);
+    @Transactional
+    public void delete(Integer id) {
+        String dir = UPLOAD_DIR + id;
+        s3ImageUploader.removeFolder(dir);
         activityRepository.deleteById(id);
 
-        return "Activity Deleted Successfully.";
+        return;
     }
 
 
-    private void saveActivityImage(Activity activity, MultipartFile multipartFile)
+    private void saveImage(Activity activity, MultipartFile multipartFile)
         throws IOException {
-        if (amazonS3Utils.isEmpty(multipartFile)) {
-            return;
-        }
-
-        boolean isCreated = activity.getId() == null;
-        if (isCreated) {
-            activityRepository.save(activity);
-        }
-
-        String uploadDir = "activityUploads/" + activity.getId();
-        String imageUrl = amazonS3Utils
-            .saveImageByFolder(uploadDir, multipartFile, isCreated);
+        String uploadDir = UPLOAD_DIR + activity.getId();
+        String imageUrl = s3ImageUploader
+            .saveImageByFolder(uploadDir, multipartFile);
         activity.changeImageUrl(imageUrl);
     }
 }

--- a/src/main/java/com/yunhalee/walkerholic/activity/service/ActivityService.java
+++ b/src/main/java/com/yunhalee/walkerholic/activity/service/ActivityService.java
@@ -9,6 +9,7 @@ import com.yunhalee.walkerholic.activity.domain.Activity;
 import com.yunhalee.walkerholic.activity.domain.ActivityRepository;
 import java.io.IOException;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,46 +17,48 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 public class ActivityService {
 
     private ActivityRepository activityRepository;
 
     private S3ImageUploader s3ImageUploader;
 
-    private static final String UPLOAD_DIR = "activityUploads/";
+    private static final String UPLOAD_DIR = "activity-uploads";
+
+    @Value("${AWS_S3_BASE_IMAGE_URL}")
+    private String defaultImageUrl;
+
+    @Value("${AWS_S3_BUCKET_URL}")
+    private String bucketUrl;
 
     public ActivityService(
-        ActivityRepository activityRepository,
-        S3ImageUploader s3ImageUploader) {
+        ActivityRepository activityRepository, S3ImageUploader s3ImageUploader) {
         this.activityRepository = activityRepository;
         this.s3ImageUploader = s3ImageUploader;
     }
 
-    @Transactional
-    public ActivityResponse create(ActivityRequest activityRequest,
-        MultipartFile multipartFile) throws IOException {
+    public ActivityResponse create(ActivityRequest activityRequest) {
         Activity activity = activityRequest.toActivity();
+        activity.setDefaultImageUrl(activityRequest.getImageUrl(), defaultImageUrl);
         activityRepository.save(activity);
-        saveImage(activity, multipartFile);
-
         return new ActivityResponse(activity);
     }
 
-    @Transactional
-    public ActivityResponse update(Integer id, ActivityRequest activityRequest,
-        MultipartFile multipartFile) throws IOException {
+    public ActivityResponse update(Integer id, ActivityRequest activityRequest) {
         Activity existingActivity = activityRepository.findById(id)
             .orElseThrow(() -> new ActivityNotFoundException(
                 "Activity not found with id : " + id));
+        System.out.println(existingActivity.getImageUrl());
+        System.out.println(existingActivity.getImageUrl().replaceAll(bucketUrl, ""));
         Activity requestActivity = activityRequest.toActivity();
+        deleteOriginalImage(requestActivity, existingActivity);
         Activity updatedActivity = existingActivity.update(requestActivity);
-        saveImage(updatedActivity, multipartFile);
 
-        return new ActivityResponse(existingActivity);
+        return new ActivityResponse(updatedActivity);
     }
 
-
+    @Transactional(readOnly = true)
     public ActivityDetailResponse activity(Integer id) {
         Activity activity = activityRepository.findByActivityId(id);
         ActivityDetailResponse activityDetailResponse = new ActivityDetailResponse(activity);
@@ -63,26 +66,35 @@ public class ActivityService {
         return activityDetailResponse;
     }
 
+    @Transactional(readOnly = true)
     public List<ActivityResponse> activities() {
-        return activityRepository.findAll().stream().map(ActivityResponse::new)
+        return activityRepository.findAll().stream()
+            .map(ActivityResponse::new)
             .collect(Collectors.toList());
     }
 
-    @Transactional
     public void delete(Integer id) {
-        String dir = UPLOAD_DIR + id;
-        s3ImageUploader.removeFolder(dir);
-        activityRepository.deleteById(id);
-
+        Activity activity = activityRepository.findById(id)
+            .orElseThrow(() -> new ActivityNotFoundException(
+                "Activity not found with id : " + id));
+        s3ImageUploader.deleteFile(activity.getImageUrl());
+        activityRepository.delete(activity);
         return;
     }
 
+    private void deleteOriginalImage(Activity requestActivity, Activity existingActivity) {
+        if (requestActivity.getImageUrl().equals(existingActivity.getImageUrl()) ||
+            existingActivity.getImageUrl().equals(defaultImageUrl)) {
+            return;
+        }
 
-    private void saveImage(Activity activity, MultipartFile multipartFile)
+        s3ImageUploader.deleteFile(existingActivity.getImageUrl().replaceAll(bucketUrl, ""));
+    }
+
+    public String uploadImage(MultipartFile multipartFile)
         throws IOException {
-        String uploadDir = UPLOAD_DIR + activity.getId();
         String imageUrl = s3ImageUploader
-            .saveImageByFolder(uploadDir, multipartFile);
-        activity.changeImageUrl(imageUrl);
+            .uploadFile(UPLOAD_DIR, multipartFile);
+        return imageUrl;
     }
 }

--- a/src/main/java/com/yunhalee/walkerholic/common/exception/AuthException.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/exception/AuthException.java
@@ -1,0 +1,16 @@
+package com.yunhalee.walkerholic.common.exception;
+
+public class AuthException extends RuntimeException {
+
+    public AuthException(String message) {
+        super(message);
+    }
+
+    public AuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AuthException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/yunhalee/walkerholic/common/exception/EntityNotFoundException.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/exception/EntityNotFoundException.java
@@ -1,0 +1,16 @@
+package com.yunhalee.walkerholic.common.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+
+    public EntityNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EntityNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/yunhalee/walkerholic/common/exception/ErrorResponse.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/exception/ErrorResponse.java
@@ -5,10 +5,18 @@ import lombok.NoArgsConstructor;
 
 
 @Data
-@NoArgsConstructor
 public class ErrorResponse {
 
-    private String message;
     private int status;
+    private String message;
     private long timestamp;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(int status, String message) {
+        this.message = message;
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/yunhalee/walkerholic/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.yunhalee.walkerholic.common.exception;
 
 
+import com.yunhalee.walkerholic.activity.exception.ActivityNotFoundException;
 import com.yunhalee.walkerholic.product.exception.NotEnoughStockException;
 import com.yunhalee.walkerholic.user.exception.UserEmailAlreadyExistException;
 import com.yunhalee.walkerholic.user.exception.UserNotFoundException;
@@ -67,6 +68,16 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, status);
     }
 
+    @ExceptionHandler(ActivityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleActivityNotFoundException(
+        ActivityNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        errorResponse.setStatus(status.value());
+        errorResponse.setMessage(e.getMessage());
+
+        return new ResponseEntity<>(errorResponse, status);
+    }
 
     @ExceptionHandler(OAuthProviderMissMatchException.class)
     public ResponseEntity<ErrorResponse> handleOAuthProviderMissMatchException(
@@ -90,9 +101,19 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleUnexpectedException(Exception e) {
         ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.NOT_FOUND;
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        errorResponse.setStatus(status.value());
+        errorResponse.setMessage(e.getMessage());
+
+        return new ResponseEntity<>(errorResponse, status);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<ErrorResponse> handleUnexpectedRuntimeException(RuntimeException e) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        HttpStatus status = HttpStatus.BAD_REQUEST;
         errorResponse.setStatus(status.value());
         errorResponse.setMessage(e.getMessage());
 

--- a/src/main/java/com/yunhalee/walkerholic/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,10 @@
 package com.yunhalee.walkerholic.common.exception;
 
 
-import com.yunhalee.walkerholic.activity.exception.ActivityNotFoundException;
-import com.yunhalee.walkerholic.product.exception.NotEnoughStockException;
-import com.yunhalee.walkerholic.user.exception.UserEmailAlreadyExistException;
-import com.yunhalee.walkerholic.user.exception.UserNotFoundException;
+import com.yunhalee.walkerholic.security.oauth.exception.OAuthProviderMissMatchException;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolationException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,105 +18,75 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
         MethodArgumentNotValidException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+        String errorMessage = e.getBindingResult().getAllErrors().stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .collect(Collectors.joining(" "));
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            errorMessage);
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
         MethodArgumentTypeMismatchException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(
+        ConstraintViolationException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(UserEmailAlreadyExistException.class)
-    public ResponseEntity<ErrorResponse> handleUserEmailAlreadyExistException(
-        UserEmailAlreadyExistException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+    @ExceptionHandler(InvalidValueException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidValueException(
+        InvalidValueException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(NotEnoughStockException.class)
-    public ResponseEntity<ErrorResponse> handleNotEnoughStockException(NotEnoughStockException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(ActivityNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleActivityNotFoundException(
-        ActivityNotFoundException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(
+        EntityNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(OAuthProviderMissMatchException.class)
-    public ResponseEntity<ErrorResponse> handleOAuthProviderMissMatchException(
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ErrorResponse> handleAuthException(
         OAuthProviderMissMatchException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
-    }
-
-    @ExceptionHandler(IllegalAccessException.class)
-    protected ResponseEntity<ErrorResponse> handleIllegalAccessException(IllegalAccessException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
-    }
-
-    @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleUnexpectedException(Exception e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.UNAUTHORIZED.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(RuntimeException.class)
-    protected ResponseEntity<ErrorResponse> handleUnexpectedRuntimeException(RuntimeException e) {
-        ErrorResponse errorResponse = new ErrorResponse();
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        errorResponse.setStatus(status.value());
-        errorResponse.setMessage(e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, status);
+    protected ResponseEntity<ErrorResponse> handleUncheckedException(RuntimeException e) {
+        e.printStackTrace();
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
 }

--- a/src/main/java/com/yunhalee/walkerholic/common/exception/InvalidValueException.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/exception/InvalidValueException.java
@@ -1,0 +1,16 @@
+package com.yunhalee.walkerholic.common.exception;
+
+public class InvalidValueException extends RuntimeException {
+
+    public InvalidValueException(String message) {
+        super(message);
+    }
+
+    public InvalidValueException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidValueException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/yunhalee/walkerholic/common/service/S3ImageUploader.java
+++ b/src/main/java/com/yunhalee/walkerholic/common/service/S3ImageUploader.java
@@ -1,4 +1,4 @@
-package com.yunhalee.walkerholic.util;
+package com.yunhalee.walkerholic.common.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
@@ -19,9 +19,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
 
-@Service
-@RequiredArgsConstructor
-public class AmazonS3Utils {
+@Component
+public class S3ImageUploader {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -35,15 +34,24 @@ public class AmazonS3Utils {
     @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
 
-    private final AmazonS3 s3;
+    @Value("${AWS_S3_BASE_IMAGE_URL}")
+    private String defaultImageUrl;
 
-    public String saveImageByFolder(String uploadDir, MultipartFile multipartFile,
-        boolean isCreated)
+    private AmazonS3 s3;
+
+    public S3ImageUploader(AmazonS3 s3) {
+        this.s3 = s3;
+    }
+
+    public String saveImageByFolder(String uploadDir, MultipartFile multipartFile)
         throws IOException {
+
+        if (isEmpty(multipartFile)) {
+            return defaultImageUrl;
+        }
+
         try {
-            if (!isCreated) {
-                removeFolder(uploadDir);
-            }
+            removeFolder(uploadDir);
             return uploadFile(uploadDir, multipartFile);
         } catch (IOException ex) {
             new IOException("Could not save file : " + multipartFile.getOriginalFilename());

--- a/src/main/java/com/yunhalee/walkerholic/post/service/PostService.java
+++ b/src/main/java/com/yunhalee/walkerholic/post/service/PostService.java
@@ -1,6 +1,6 @@
 package com.yunhalee.walkerholic.post.service;
 
-import com.yunhalee.walkerholic.util.AmazonS3Utils;
+import com.yunhalee.walkerholic.common.service.S3ImageUploader;
 import com.yunhalee.walkerholic.util.FileUploadUtils;
 import com.yunhalee.walkerholic.post.dto.PostCreateDTO;
 import com.yunhalee.walkerholic.post.dto.PostDTO;
@@ -41,7 +41,7 @@ public class PostService {
 
     public static final int POST_PER_PAGE = 9;
 
-    private final AmazonS3Utils amazonS3Utils;
+    private final S3ImageUploader s3ImageUploader;
 
     @Value("${AWS_S3_BUCKET_URL}")
     private String AWS_S3_BUCKET_URL;
@@ -50,7 +50,7 @@ public class PostService {
         for (String deletedImage : deletedImages) {
             postImageRepository.deleteByFilePath(deletedImage);
             String fileName = deletedImage.substring(AWS_S3_BUCKET_URL.length() + 1);
-            amazonS3Utils.deleteFile(fileName);
+            s3ImageUploader.deleteFile(fileName);
         }
     }
 
@@ -61,7 +61,7 @@ public class PostService {
 
             try {
                 String uploadDir = "postUploads/" + post.getId();
-                String imageUrl = amazonS3Utils.uploadFile(uploadDir, multipartFile);
+                String imageUrl = s3ImageUploader.uploadFile(uploadDir, multipartFile);
                 String fileName = imageUrl
                     .substring(AWS_S3_BUCKET_URL.length() + uploadDir.length() + 2);
                 postImage.setName(fileName);

--- a/src/main/java/com/yunhalee/walkerholic/product/exception/NotEnoughStockException.java
+++ b/src/main/java/com/yunhalee/walkerholic/product/exception/NotEnoughStockException.java
@@ -1,6 +1,8 @@
 package com.yunhalee.walkerholic.product.exception;
 
-public class NotEnoughStockException extends RuntimeException {
+import com.yunhalee.walkerholic.common.exception.BadRequestException;
+
+public class NotEnoughStockException extends BadRequestException {
 
     public NotEnoughStockException(String message) {
         super(message);

--- a/src/main/java/com/yunhalee/walkerholic/product/service/ProductService.java
+++ b/src/main/java/com/yunhalee/walkerholic/product/service/ProductService.java
@@ -4,7 +4,7 @@ import com.yunhalee.walkerholic.product.dto.ProductCreateDTO;
 import com.yunhalee.walkerholic.product.dto.ProductDTO;
 import com.yunhalee.walkerholic.product.dto.ProductListDTO;
 import com.yunhalee.walkerholic.user.dto.UserSellerDTO;
-import com.yunhalee.walkerholic.util.AmazonS3Utils;
+import com.yunhalee.walkerholic.common.service.S3ImageUploader;
 import com.yunhalee.walkerholic.util.FileUploadUtils;
 import com.yunhalee.walkerholic.product.domain.Category;
 import com.yunhalee.walkerholic.product.domain.Product;
@@ -41,7 +41,7 @@ public class ProductService {
 
     public static final int PRODUCT_LIST_PER_PAGE = 10;
 
-    private final AmazonS3Utils amazonS3Utils;
+    private final S3ImageUploader s3ImageUploader;
 
     @Value("${AWS_S3_BUCKET_URL}")
     private String AWS_S3_BUCKET_URL;
@@ -50,7 +50,7 @@ public class ProductService {
         for (String deletedImage : deletedImages) {
             productImageRepository.deleteByFilePath(deletedImage);
             String fileName = deletedImage.substring(AWS_S3_BUCKET_URL.length()+1);
-            amazonS3Utils.deleteFile(fileName);
+            s3ImageUploader.deleteFile(fileName);
         }
     }
 
@@ -59,7 +59,7 @@ public class ProductService {
             ProductImage productImage = new ProductImage();
             try{
                 String uploadDir = "productUploads/" + product.getId();
-                String imageUrl = amazonS3Utils.uploadFile(uploadDir, multipartFile);
+                String imageUrl = s3ImageUploader.uploadFile(uploadDir, multipartFile);
                 String fileName = imageUrl.substring(AWS_S3_BUCKET_URL.length()+uploadDir.length()+2);
                 productImage.setName(fileName);
                 productImage.setFilePath(imageUrl);

--- a/src/main/java/com/yunhalee/walkerholic/security/oauth/exception/OAuthProviderMissMatchException.java
+++ b/src/main/java/com/yunhalee/walkerholic/security/oauth/exception/OAuthProviderMissMatchException.java
@@ -1,6 +1,8 @@
-package com.yunhalee.walkerholic.common.exception;
+package com.yunhalee.walkerholic.security.oauth.exception;
 
-public class OAuthProviderMissMatchException extends RuntimeException {
+import com.yunhalee.walkerholic.common.exception.InvalidValueException;
+
+public class OAuthProviderMissMatchException extends InvalidValueException {
 
     public OAuthProviderMissMatchException(String message) {
         super(message);

--- a/src/main/java/com/yunhalee/walkerholic/security/oauth/service/CustomOauth2UserService.java
+++ b/src/main/java/com/yunhalee/walkerholic/security/oauth/service/CustomOauth2UserService.java
@@ -5,7 +5,7 @@ import com.yunhalee.walkerholic.security.jwt.domain.JwtUserDetails;
 import com.yunhalee.walkerholic.user.domain.Level;
 import com.yunhalee.walkerholic.user.domain.Role;
 import com.yunhalee.walkerholic.user.domain.User;
-import com.yunhalee.walkerholic.common.exception.OAuthProviderMissMatchException;
+import com.yunhalee.walkerholic.security.oauth.exception.OAuthProviderMissMatchException;
 import com.yunhalee.walkerholic.user.domain.UserRepository;
 import com.yunhalee.walkerholic.security.oauth.domain.OAuth2UserInfo;
 import com.yunhalee.walkerholic.security.oauth.domain.OAuth2UserInfoFactory;

--- a/src/main/java/com/yunhalee/walkerholic/user/exception/UserEmailAlreadyExistException.java
+++ b/src/main/java/com/yunhalee/walkerholic/user/exception/UserEmailAlreadyExistException.java
@@ -1,6 +1,8 @@
 package com.yunhalee.walkerholic.user.exception;
 
-public class UserEmailAlreadyExistException extends RuntimeException {
+import com.yunhalee.walkerholic.common.exception.InvalidValueException;
+
+public class UserEmailAlreadyExistException extends InvalidValueException {
 
     public UserEmailAlreadyExistException(String message) {
         super(message);

--- a/src/main/java/com/yunhalee/walkerholic/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/yunhalee/walkerholic/user/exception/UserNotFoundException.java
@@ -1,7 +1,9 @@
 package com.yunhalee.walkerholic.user.exception;
 
 
-public class UserNotFoundException extends RuntimeException {
+import com.yunhalee.walkerholic.common.exception.EntityNotFoundException;
+
+public class UserNotFoundException extends EntityNotFoundException {
 
     public UserNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/yunhalee/walkerholic/user/service/UserService.java
+++ b/src/main/java/com/yunhalee/walkerholic/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.yunhalee.walkerholic.user.service;
 
-import com.yunhalee.walkerholic.util.AmazonS3Utils;
+import com.yunhalee.walkerholic.common.service.S3ImageUploader;
 import com.yunhalee.walkerholic.util.FileUploadUtils;
 import com.yunhalee.walkerholic.user.dto.UserDTO;
 import com.yunhalee.walkerholic.user.dto.UserListDTO;
@@ -44,7 +44,7 @@ public class UserService {
     @Value("${spring.mail.username}")
     private String sender;
 
-    private final AmazonS3Utils amazonS3Utils;
+    private final S3ImageUploader s3ImageUploader;
 
 
     private void saveProfileFile(MultipartFile multipartFile, User user, boolean isNew)
@@ -52,9 +52,9 @@ public class UserService {
         try {
             String uploadDir = "profileUploads/" + user.getId();
             if (!isNew) {
-                amazonS3Utils.removeFolder(uploadDir);
+                s3ImageUploader.removeFolder(uploadDir);
             }
-            String imageUrl = amazonS3Utils.uploadFile(uploadDir, multipartFile);
+            String imageUrl = s3ImageUploader.uploadFile(uploadDir, multipartFile);
             user.setImageUrl(imageUrl);
 
         } catch (IOException ex) {

--- a/src/main/java/com/yunhalee/walkerholic/util/AmazonS3Utils.java
+++ b/src/main/java/com/yunhalee/walkerholic/util/AmazonS3Utils.java
@@ -2,6 +2,7 @@ package com.yunhalee.walkerholic.util;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,20 @@ public class AmazonS3Utils {
 
     private final AmazonS3 s3;
 
+    public String saveImageByFolder(String uploadDir, MultipartFile multipartFile,
+        boolean isCreated)
+        throws IOException {
+        try {
+            if (!isCreated) {
+                removeFolder(uploadDir);
+            }
+            return uploadFile(uploadDir, multipartFile);
+        } catch (IOException ex) {
+            new IOException("Could not save file : " + multipartFile.getOriginalFilename());
+        }
+        return "";
+    }
+
     public List<String> listFolder(String folder) {
 
         ListObjectsV2Request listObjectsV2Request = new ListObjectsV2Request()
@@ -65,6 +80,10 @@ public class AmazonS3Utils {
     public void deleteFile(String fileName) {
         DeleteObjectRequest request = new DeleteObjectRequest(bucket, fileName);
         s3.deleteObject(request);
+    }
+
+    public boolean isEmpty(MultipartFile multipartFile) {
+        return Objects.isNull(multipartFile) || multipartFile.isEmpty();
     }
 
     public void removeFolder(String folderName) {

--- a/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
@@ -31,7 +31,9 @@ public class ActivityServiceTests {
     ActivityRepository activityRepository;
 
     @Value("${AWS_S3_BUCKET_URL}")
-    private String AWS_S3_BUCKET_URL;
+    private String bucketUrl;
+
+    private static final String UPLOAD_URL = "activityUploads/";
 
     @Test
     public void createActivity() throws IOException {
@@ -39,24 +41,25 @@ public class ActivityServiceTests {
         String name = "testActivity";
         Integer score = 1;
         String description = "This is test Activity.";
+        String fileName = "sampleFile.txt";
 
         ActivityRequest activityRequest = new ActivityRequest(name, score, description);
         MultipartFile multipartFile = new MockMultipartFile("uploaded-file",
-            "sampleFile.txt",
+            fileName,
             "text/plain",
             "This is the file content".getBytes());
         //when
-        ActivityResponse activityResponse1 = activityService
+        ActivityResponse activityResponse = activityService
             .create(activityRequest, multipartFile);
 
         //then
-        assertNotNull(activityResponse1.getId());
-        assertEquals(name, activityResponse1.getName());
-        assertEquals(score, activityResponse1.getScore());
-        assertEquals(description, activityResponse1.getDescription());
-        assertTrue(activityResponse1.getImageUrl()
-            .contains(AWS_S3_BUCKET_URL + "activityUploads/" + activityResponse1.getId() + "/"));
-        assertTrue(activityResponse1.getImageUrl().contains("sampleFile.txt"));
+        assertNotNull(activityResponse.getId());
+        assertEquals(name, activityResponse.getName());
+        assertEquals(score, activityResponse.getScore());
+        assertEquals(description, activityResponse.getDescription());
+        assertTrue(activityResponse.getImageUrl()
+            .contains(bucketUrl + UPLOAD_URL + activityResponse.getId() + "/"));
+        assertTrue(activityResponse.getImageUrl().contains(fileName));
     }
 
     @Test
@@ -84,7 +87,7 @@ public class ActivityServiceTests {
         Integer id = 1;
 
         //when
-        ActivityDetailResponse activityDetailResponse = activityService.getActivity(id);
+        ActivityDetailResponse activityDetailResponse = activityService.activity(id);
 
         //then
         assertEquals(id, activityDetailResponse.getId());
@@ -95,7 +98,7 @@ public class ActivityServiceTests {
         //given
 
         //when
-        List<ActivityResponse> activityResponses = activityService.getActivities();
+        List<ActivityResponse> activityResponses = activityService.activities();
 
         //then
         assertEquals(1, activityResponses.size());
@@ -107,7 +110,7 @@ public class ActivityServiceTests {
         Integer id = 1;
 
         //when
-        activityService.deleteActivity(id);
+        activityService.delete(id);
 
         //then
         assertNull(activityRepository.findById(id));

--- a/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/activity/service/ActivityServiceTests.java
@@ -74,11 +74,11 @@ public class ActivityServiceTests {
         ActivityRequest activityRequest = new ActivityRequest(name, score, description);
 
         //when
-        ActivityResponse activityResponse1 = activityService
+        ActivityResponse activityResponse = activityService
             .update(id, activityRequest, null);
 
         //then
-        assertNotEquals(originalName, activityResponse1.getName());
+        assertNotEquals(originalName, activityResponse.getName());
     }
 
     @Test

--- a/src/test/java/com/yunhalee/walkerholic/util/S3ImageUploaderTests.java
+++ b/src/test/java/com/yunhalee/walkerholic/util/S3ImageUploaderTests.java
@@ -1,6 +1,6 @@
 package com.yunhalee.walkerholic.util;
 
-import com.yunhalee.walkerholic.util.AmazonS3Utils;
+import com.yunhalee.walkerholic.common.service.S3ImageUploader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,10 +20,10 @@ import static org.junit.Assert.*;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional
-public class AmazonS3UtilsTests {
+public class S3ImageUploaderTests {
 
     @Autowired
-    AmazonS3Utils amazonS3Utils;
+    S3ImageUploader s3ImageUploader;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -44,7 +44,7 @@ public class AmazonS3UtilsTests {
         String folderName = "postUploads";
 
         //when
-        List<String> list = amazonS3Utils.listFolder(folderName);
+        List<String> list = s3ImageUploader.listFolder(folderName);
 
         //then
         for (String s : list) {
@@ -68,7 +68,7 @@ public class AmazonS3UtilsTests {
         };
 
         //when
-        String imageUrl = amazonS3Utils.uploadFile(folderName, multipartFile);
+        String imageUrl = s3ImageUploader.uploadFile(folderName, multipartFile);
 
         //then
         System.out.println(imageUrl);
@@ -84,11 +84,11 @@ public class AmazonS3UtilsTests {
             "text/plain",
             "This is the file content".getBytes()) {
         };
-        amazonS3Utils.uploadFile(folderName, multipartFile);
+        s3ImageUploader.uploadFile(folderName, multipartFile);
 
         //when
-        amazonS3Utils.deleteFile("testUploads/sampleFile.txt");
-        List<String> list = amazonS3Utils.listFolder(folderName);
+        s3ImageUploader.deleteFile("testUploads/sampleFile.txt");
+        List<String> list = s3ImageUploader.listFolder(folderName);
 
         //then
         for (String s : list) {
@@ -106,11 +106,11 @@ public class AmazonS3UtilsTests {
             "text/plain",
             "This is the file content".getBytes()) {
         };
-        amazonS3Utils.uploadFile(folderName, multipartFile);
+        s3ImageUploader.uploadFile(folderName, multipartFile);
 
         //when
-        amazonS3Utils.removeFolder(folderName);
-        List<String> list = amazonS3Utils.listFolder(folderName);
+        s3ImageUploader.removeFolder(folderName);
+        List<String> list = s3ImageUploader.listFolder(folderName);
 
         //then
         assertEquals(list.size(), 0);


### PR DESCRIPTION
Activity 기능과 관련된 항목을 리팩토링 진행하였습니다.

ActivityService에 saveActivity로 단일화 되었던 메소드는 updateActivity, createActivity로 분리하여 역할을 분명하게 하고, setter를 이용한 값변경을 activity 엔티티내의 updateActivity 비지니스 로직을 이용한 변경으로 바꾸어 메소드의 목적을 알 수 있게 하였습니다.

ActivityCreateDTO에서는 toActivity함수를 만들어 Activity생성자를 이용하여 정보를 포함한 새로운 activity를 반환할 수 있도록 하였습니다.